### PR TITLE
chore: Add 'ip' package as a peer dependency

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -116,6 +116,11 @@
       "type": "peer"
     },
     {
+      "name": "ip",
+      "version": "2.0.1",
+      "type": "peer"
+    },
+    {
       "name": "projen",
       "type": "peer"
     }

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -314,7 +314,7 @@
           "exec": "pnpm i --no-frozen-lockfile"
         },
         {
-          "exec": "pnpm update @stylistic/eslint-plugin @types/babel__core @types/fs-extra @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser commit-and-tag-version constructs eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii projen ts-jest ts-node typescript commander fs-extra"
+          "exec": "pnpm update @stylistic/eslint-plugin @types/babel__core @types/fs-extra @types/jest @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser commit-and-tag-version constructs eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii projen ts-jest ts-node typescript commander fs-extra ip"
         },
         {
           "exec": "pnpm exec projen"

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -25,6 +25,7 @@ const project = new cdk.JsiiProject({
   peerDeps: [
     'projen',
     'constructs',
+    'ip@2.0.1',
   ],
   devDeps: [
     '@types/babel__core',

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "eslint": "^9",
     "eslint-import-resolver-typescript": "^3.10.1",
     "eslint-plugin-import": "^2.32.0",
+    "ip": "2.0.1",
     "jest": "^29.7.0",
     "jest-junit": "^17",
     "jsii": "5.9.x",
@@ -66,6 +67,7 @@
   },
   "peerDependencies": {
     "constructs": "^10.6.0",
+    "ip": "2.0.1",
     "projen": "^0.99.70"
   },
   "dependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       eslint-plugin-import:
         specifier: ^2.32.0
         version: 2.32.0(@typescript-eslint/parser@8.60.0(eslint@9.39.4)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4)
+      ip:
+        specifier: 2.0.1
+        version: 2.0.1
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.19.41)(ts-node@10.9.2(@types/node@20.19.41)(typescript@5.9.3))
@@ -1636,6 +1639,9 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  ip@2.0.1:
+    resolution: {integrity: sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==}
 
   is-array-buffer@3.0.5:
     resolution: {integrity: sha512-DDfANUiiG2wC1qawP66qlTugJeL5HyzMpfr8lLK+jMQirGzNod0B12cFB/9q838Ru27sBwfw78/rdoU7RERz6A==}
@@ -4807,6 +4813,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.2
       side-channel: 1.1.0
+
+  ip@2.0.1: {}
 
   is-array-buffer@3.0.5:
     dependencies:


### PR DESCRIPTION
Add the 'ip' package as a peer dependency in the project configuration and update relevant scripts and lock files accordingly.

