### PR TITLE
feat(lerna-ts-project): Enhance TypeScript project options parsing to include default srcdir

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ $ npx projen new --from lerna-projen lerna-ts-project
 
 The project type can be anything to start with, then in the `projenrc` file, initiate a lerna project and add all of the sub normal projen project to the lerna project.
 
+> **Note:** `LernaTypescriptProject` defaults `srcdir` to `'projenrc'` instead of the projen default of `'src'`.
+
 ### Example for TS
 ```javascript
 import {LernaTypescriptProject} from 'lerna-projen';

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,13 @@ function appendWorkflowBootstrapSteps<T extends LernaProjectOptions | LernaTypes
   };
 }
 
+function parseTsOptions(options: LernaTypescriptProjectOptions): LernaTypescriptProjectOptions {
+  return {
+    ...options,
+    srcdir: options.srcdir ?? 'projenrc',
+  };
+}
+
 const lockedTaskNames = ['build', 'upgrade', 'upgrade-projen', 'clobber', 'post-upgrade'];
 
 interface ILernaProject {
@@ -128,7 +135,7 @@ export class LernaTypescriptProject extends typescript.TypeScriptProject impleme
   private readonly factory: LernaProjectFactory;
 
   constructor(options: LernaTypescriptProjectOptions) {
-    super(appendWorkflowBootstrapSteps(options));
+    super(appendWorkflowBootstrapSteps(parseTsOptions(options)));
 
     this.sinceLastRelease = options.sinceLastRelease ?? false;
     this.useNx = options.useNx ?? false;


### PR DESCRIPTION
Enhance the parsing of TypeScript project options to set a default source directory if none is provided. This change is to fix the issue of files in `projenrc` folder failing the eslint command, after release of new `tsconfig` structure in projen.
